### PR TITLE
Correcting some links and adding new ones

### DIFF
--- a/README.md
+++ b/README.md
@@ -514,7 +514,6 @@ games
 ### 🧩 Misc
 - [AR Play Cards](https://www.retrocomputers.gr/media/kunena/attachments/155/AR-Play-Cards.pdf) - Augmented Reality cards for PS Vita
 - [Android games](https://android.rinnegatamante.it) - List of Android games theoretically portable to PS Vita
-- [Unity games](https://docs.google.com/spreadsheets/d/1Hhxr2ODdtAlR8WM08m9v7yVi4_crwoXQe0XvSnd1raU/edit#gid=0) - List of Unity games theoretically portable to PS Vita
 - [Bounties](https://github.com/vita-nuova/bounties/issues) - Bounties for new Vita projects
 - [Compass](https://www.reddit.com/r/vitahacks/comments/us2woq/not_release_simple_compass_for_ps_vita) - Built in Vita browser compass/gyro app ([about:compass](about:compass))
 - [LiveRig](https://github.com/GrapheneCt/LiveRig) - Live2D face tracking software PoC


### PR DESCRIPTION
In this MR I went through all the links and added one link for developers.

- **pFBN**: corrected the link to the whole repository link. The old one was leading to an error;
- **ScummVM**: corrected the link to another archive link. The old one was leading to an error;
- **Quietshot**: apparently, the repository is hidden or removed, I found the plugin on [store.brewology](https://store.brewology.com);
- **vitatricks**: apparently, the site has changed the domain (`.tk`->`.xyz`);
- **God of War Remastered Videos**: Discord links are not valid, found similar information on Reddit;
- **Sly Cooper Remastered Videos**: Discord links are not valid, found similar information on Reddit;
- **PSMRC**: apparently the site is unavailable, changed the link to the site repository, which was deployed;
- **Unity games**: the table is no longer available, I could not find analogues;
- **Vitadev Package manager**: script for developers, convenient and popular.